### PR TITLE
fix: Updated URL based on rcmdcheck note

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -37,7 +37,7 @@ Authors@R: c(
 Description: Provides a generic framework for working with YAML
     configuration files, including using 'ajv' for validation.
 License: Apache License (>= 2)
-URL: https://NovoNordisk-OpenSource.github.io/S7schema
+URL: https://novonordisk-opensource.github.io/S7schema/
 Depends: 
     R (>= 4.1)
 Imports: 


### PR DESCRIPTION
## Summary
Running `rcmdcheck::rcmdcheck(args = c("--as-cran"))` returns the following Note:
```r
Found the following (possibly) invalid URLs:
     URL: [https://NovoNordisk-OpenSource.github.io/S7schema](vscode-file://vscode-app/Applications/Positron.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html#) (moved to [https://novonordisk-opensource.github.io/S7schema/](vscode-file://vscode-app/Applications/Positron.app/Contents/Resources/app/out/vs/code/electron-browser/workbench/workbench.html#))
       From: DESCRIPTION
       Status: 200
       Message: OK
```

## Changes Made
Updates the URL in DESCRIPTION to use lowercase and include trailing slash

## Testing
- All tests pass

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge
