### PR TITLE
fix: language statistics

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+inst/bundle.js linguist-generated


### PR DESCRIPTION
## Summary
Adds `.gitattributes` specifying `inst/bundle.js` as a generated script ensuring it is not included in GitHub language statistics.

## Changes Made
- Added `.gitattributes`

## Testing
- No relevant changes.

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge
