### PR TITLE
fix: zero-indexed error paths

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: S7schema
 Title: Generic 'S7' Implementation of YAML Config with Schema Based Validation
-Version: 0.0.0.9006
+Version: 0.0.0.9007
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Novo Nordisk A/S", role = "cph"),

--- a/R/validator.R
+++ b/R/validator.R
@@ -51,6 +51,20 @@ validator <- S7::new_class(
 )
 
 #' @noRd
+fix_index <- function(path) {
+  m <- gregexpr(
+    pattern = "(?<=/)\\d+(?=/|$)",
+    text = path,
+    perl = TRUE
+  )
+  regmatches(x = path, m = m) <- lapply(
+    X = regmatches(x = path, m = m),
+    FUN = \(x) as.integer(x) + 1L
+  )
+  path
+}
+
+#' @noRd
 use_validator <- function(validator, yaml_content) {
   validator@context$assign(
     name = "yaml_str",
@@ -73,7 +87,7 @@ use_validator <- function(validator, yaml_content) {
   error <- result$errors[[1]]
   cli::cli_abort(
     message = c(
-      "{.field {error$instancePath}} {error$message}",
+      "{.field {fix_index(error$instancePath)}} {error$message}",
       rlang::set_names(
         x = paste(names(error$params), error$params, sep = ": "),
         nm = "x"

--- a/tests/testthat/schemas/array.json
+++ b/tests/testthat/schemas/array.json
@@ -1,0 +1,14 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema",
+  "title": "Array example",
+  "description": "Schema with array property for testing index conversion",
+  "type": "object",
+  "properties": {
+    "my_array": {
+      "description": "Array of strings",
+      "type": "array",
+      "items": { "type": "string" }
+    }
+  },
+  "additionalProperties": false
+}

--- a/tests/testthat/test-validate-config.R
+++ b/tests/testthat/test-validate-config.R
@@ -25,6 +25,20 @@ test_that("simple validation on lists works", {
     )
 })
 
+test_that("array validation errors use 1-based indexing", {
+  validate_list(
+    x = list(my_array = list("a", "b")),
+    schema = test_path("schemas", "array.json")
+  ) |>
+    expect_no_condition()
+
+  validate_list(
+    x = list(my_array = list("a", 1)),
+    schema = test_path("schemas", "array.json")
+  ) |>
+    expect_error("/my_array/2 must be string")
+})
+
 test_that("simple validation of yaml files works", {
   validate_yaml(
     file = test_path("input", "simple.yml"),

--- a/tests/testthat/test-validator.R
+++ b/tests/testthat/test-validator.R
@@ -1,0 +1,17 @@
+test_that("fix_index", {
+  # single numeric segment
+  expect_equal(fix_index("/items/0"), "/items/1")
+  expect_equal(fix_index("/items/1"), "/items/2")
+
+  # multiple numeric segments
+  expect_equal(fix_index("/a/0/b/2"), "/a/1/b/3")
+
+  # no numeric segments — unchanged
+  expect_equal(fix_index("/foo/bar"), "/foo/bar")
+
+  # empty path
+  expect_equal(fix_index(""), "")
+
+  # root-level numeric segment
+  expect_equal(fix_index("/0"), "/1")
+})


### PR DESCRIPTION
## Summary
Validation error paths from ajv use 0-based array indices. This converts them to 1-based indexing to match R conventions.

Closes #35

## Changes Made
- Added `fix_index()` helper using `gregexpr`/`regmatches` to increment numeric path segments
- Applied `fix_index()` to error instance paths in `use_validator()`

## Testing
- Unit tests for `fix_index()` directly (`test-validator.R`)
- Integration test asserting 1-based index in array validation errors (`test-validate-config.R`)

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge