### PR TITLE
feat: initial CRAN release

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -15,3 +15,4 @@
 ^S7schema\.Rproj$
 ^cran-comments\.md$
 ^\.claude$
+^CRAN-SUBMISSION$

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,3 +1,0 @@
-Version: 0.1.0
-Date: 2026-03-09 14:53:56 UTC
-SHA: a4e46cd7dd5fc7b4a9b2a96814ef7cc2cc032c4f

--- a/CRAN-SUBMISSION
+++ b/CRAN-SUBMISSION
@@ -1,0 +1,3 @@
+Version: 0.1.0
+Date: 2026-03-09 14:53:56 UTC
+SHA: a4e46cd7dd5fc7b4a9b2a96814ef7cc2cc032c4f

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,7 +24,7 @@ Description: Provides a generic framework for working with YAML (YAML
     and methods.
 License: Apache License (>= 2)
 URL: https://novonordisk-opensource.github.io/S7schema/,
-    https://github.com/novonordisk-opensource/S7schema
+    https://github.com/NovoNordisk-OpenSource/S7schema
 BugReports: https://github.com/NovoNordisk-OpenSource/S7schema/issues
 Depends: 
     R (>= 4.1)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: S7schema
 Title: 'S7' Framework for Schema-Validated YAML Configuration
-Version: 0.0.0.9014
+Version: 0.1.0
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Matthew", "Phelps", , "mewp@novonordisk.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,3 @@
 # S7schema 0.1.0
 
-* Prepare for initial CRAN submission.
+* Initial CRAN submission.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,3 @@
-# S7schema (development version)
+# S7schema 0.1.0
 
 * Prepare for initial CRAN submission.

--- a/R/z_document.R
+++ b/R/z_document.R
@@ -72,6 +72,7 @@ document_schema_list <- function(x, header_start_level) {
   rlang::check_installed("tidyr")
   rlang::check_installed("tibble")
   rlang::check_installed("purrr")
+  rlang::check_installed("withr")
 
   x |>
     doc_ref_hyperlinks() |>

--- a/README.Rmd
+++ b/README.Rmd
@@ -29,6 +29,9 @@ in the `S7schema()` class that:
 ## Installation
 
 ```{r, eval=FALSE}
+# Install the latest released version from CRAN:
+install.packages("S7schema")
+
 # Install the development version from GitHub:
 pak::pak("NovoNordisk-OpenSource/S7schema")
 ```

--- a/README.md
+++ b/README.md
@@ -21,6 +21,9 @@ main functionality is captured in the `S7schema()` class that:
 ## Installation
 
 ``` r
+# Install the latest released version from CRAN:
+install.packages("S7schema")
+
 # Install the development version from GitHub:
 pak::pak("NovoNordisk-OpenSource/S7schema")
 ```

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,15 +1,5 @@
 ## R CMD check results
 
-0 errors | 0 warnings | 0 notes
+0 errors | 0 warnings | 1 note
 
-## Test environments
-
-* local macOS (aarch64-apple-darwin), R 4.4.x
-* GitHub Actions: ubuntu-latest (release)
-* GitHub Actions: ubuntu-latest (devel)
-* GitHub Actions: macOS-latest (release)
-* GitHub Actions: windows-latest (release)
-
-## Downstream dependencies
-
-This is a new package with no reverse dependencies.
+* This is a new release.


### PR DESCRIPTION
## Summary
Initial CRAN release (v0.1.0).
See https://cran.r-project.org/package=S7schema.

Closes #8

## Changes Made
- Bump version to 0.1.0 for initial release
- Clean up DESCRIPTION URLs
- Add CRAN install instructions to README
- Fix missing `withr` install check in `document_schema`

## Testing
- All tests passes and accepted to CRAN

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge