### PR TITLE
fix: rework write_config() file argument

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: S7schema
 Title: 'S7' Framework for Schema-Validated YAML Configuration
-Version: 0.1.0
+Version: 0.1.0.9000
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Matthew", "Phelps", , "mewp@novonordisk.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # S7schema (development version)
 
+* Fixed `write_config()` to use `NULL` as the default `file` argument instead of `x@file`, allowing method implementations to define their own defaults (#48).
+
 # S7schema 0.1.0
 
 * Initial CRAN submission.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # S7schema (development version)
 
-* Fixed `write_config()` to use `NULL` as the default `file` argument instead of `x@file`, allowing method implementations to define their own defaults (#48).
+* Fixed `write_config()` to use `NULL` as the default for the output path instead of `x@file`, and renamed the `file` argument to `path` (#48).
 
 # S7schema 0.1.0
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,5 @@
+# S7schema (development version)
+
 # S7schema 0.1.0
 
 * Initial CRAN submission.

--- a/R/z_write.R
+++ b/R/z_write.R
@@ -4,7 +4,7 @@
 #' converting to YAML and creating the file, ensuring that the saved configuration is valid.
 #'
 #' @param x `S7schema` object to write.
-#' @param file `character(1)` path to the file to write to. Default `NULL` uses `x@file` for `S7schema()` objects.
+#' @param path `character(1)` path to the file to write to. Default `NULL` uses `x@file` for `S7schema()` objects.
 #' @return Invisible `x` (the input `S7schema` object). Called for side effect
 #'   of writing the file.
 #' @examples
@@ -22,34 +22,34 @@
 #' # Save new file
 #' write_config(
 #'   x = x,
-#'   file = tempfile(fileext = ".yml")
+#'   path = tempfile(fileext = ".yml")
 #' )
 #'
 #' @export
 write_config <- S7::new_generic(
   name = "write_config",
   dispatch_args = "x",
-  fun = \(x, file = NULL) {
+  fun = \(x, path = NULL) {
     S7::S7_dispatch()
   }
 )
 
 #' @noRd
-S7::method(write_config, S7schema) <- function(x, file = NULL) {
-  write_valid_config(x, file)
+S7::method(write_config, S7schema) <- function(x, path = NULL) {
+  write_valid_config(x, path)
 }
 
 #' @noRd
-write_valid_config <- function(x, file) {
+write_valid_config <- function(x, path) {
   validate(x)
 
-  if (is.null(file)) {
-    file <- x@file
+  if (is.null(path)) {
+    path <- x@file
   }
 
   cat(
     result = to_yaml(x),
-    file = file,
+    file = path,
     sep = ""
   )
 

--- a/R/z_write.R
+++ b/R/z_write.R
@@ -4,7 +4,7 @@
 #' converting to YAML and creating the file, ensuring that the saved configuration is valid.
 #'
 #' @param x `S7schema` object to write.
-#' @param file `character(1)` path to the file to write to. Defaults to `x@file` if not provided.
+#' @param file `character(1)` path to the file to write to. Default `NULL` uses `x@file` for `S7schema()` objects.
 #' @return Invisible `x` (the input `S7schema` object). Called for side effect
 #'   of writing the file.
 #' @examples

--- a/R/z_write.R
+++ b/R/z_write.R
@@ -29,19 +29,23 @@
 write_config <- S7::new_generic(
   name = "write_config",
   dispatch_args = "x",
-  fun = \(x, file = x@file) {
+  fun = \(x, file = NULL) {
     S7::S7_dispatch()
   }
 )
 
 #' @noRd
-S7::method(write_config, S7schema) <- function(x, file = x@file) {
+S7::method(write_config, S7schema) <- function(x, file = NULL) {
   write_valid_config(x, file)
 }
 
 #' @noRd
 write_valid_config <- function(x, file) {
   validate(x)
+
+  if (is.null(file)) {
+    file <- x@file
+  }
 
   cat(
     result = to_yaml(x),

--- a/man/write_config.Rd
+++ b/man/write_config.Rd
@@ -4,12 +4,12 @@
 \alias{write_config}
 \title{Write YAML configuration file}
 \usage{
-write_config(x, file = NULL)
+write_config(x, path = NULL)
 }
 \arguments{
 \item{x}{\code{S7schema} object to write.}
 
-\item{file}{\code{character(1)} path to the file to write to. Default \code{NULL} uses \code{x@file} for \code{S7schema()} objects.}
+\item{path}{\code{character(1)} path to the file to write to. Default \code{NULL} uses \code{x@file} for \code{S7schema()} objects.}
 }
 \value{
 Invisible \code{x} (the input \code{S7schema} object). Called for side effect
@@ -34,7 +34,7 @@ x$my_config_var <- 2
 # Save new file
 write_config(
   x = x,
-  file = tempfile(fileext = ".yml")
+  path = tempfile(fileext = ".yml")
 )
 
 }

--- a/man/write_config.Rd
+++ b/man/write_config.Rd
@@ -4,7 +4,7 @@
 \alias{write_config}
 \title{Write YAML configuration file}
 \usage{
-write_config(x, file = x@file)
+write_config(x, file = NULL)
 }
 \arguments{
 \item{x}{\code{S7schema} object to write.}

--- a/man/write_config.Rd
+++ b/man/write_config.Rd
@@ -9,7 +9,7 @@ write_config(x, file = NULL)
 \arguments{
 \item{x}{\code{S7schema} object to write.}
 
-\item{file}{\code{character(1)} path to the file to write to. Defaults to \code{x@file} if not provided.}
+\item{file}{\code{character(1)} path to the file to write to. Default \code{NULL} uses \code{x@file} for \code{S7schema()} objects.}
 }
 \value{
 Invisible \code{x} (the input \code{S7schema} object). Called for side effect

--- a/tests/testthat/test-z_write.R
+++ b/tests/testthat/test-z_write.R
@@ -6,7 +6,7 @@ test_that("writing works", {
 
   tmpfile <- withr::local_tempfile(fileext = ".yml")
 
-  write_config(x = x, file = tmpfile) |>
+  write_config(x = x, path = tmpfile) |>
     expect_no_condition()
 
   file.exists(tmpfile) |>

--- a/tests/testthat/test-z_write.R
+++ b/tests/testthat/test-z_write.R
@@ -21,3 +21,29 @@ test_that("writing works", {
   expect_equal(S7::S7_data(x), S7::S7_data(y))
   expect_equal(x@schema, y@schema)
 })
+
+test_that("default for S7schema class", {
+  tmpfile <- withr::local_tempfile(
+    lines = readLines(test_path("input", "simple.yml")),
+    fileext = ".yml"
+  )
+
+  x <- S7schema(
+    file = tmpfile,
+    schema = test_path("schemas", "simple.json")
+  )
+
+  expect_equal(x$id, "abc")
+
+  x$id <- "d"
+
+  write_config(x) |>
+    expect_no_condition()
+
+  y <- S7schema(
+    file = tmpfile,
+    schema = test_path("schemas", "simple.json")
+  )
+
+  expect_equal(y$id, "d")
+})

--- a/vignettes/S7schema.Rmd
+++ b/vignettes/S7schema.Rmd
@@ -97,7 +97,7 @@ To save a configuration use `write_config()`:
 ```{r, eval = FALSE}
 write_config(
   x = config,
-  file = "my/config.yml"
+  path = "my/config.yml"
 )
 ```
 

--- a/vignettes/use-in-package.Rmd
+++ b/vignettes/use-in-package.Rmd
@@ -109,7 +109,7 @@ Methods defined for `S7schema` work on child classes without extra code.
 ```{r}
 tmp <- tempfile(fileext = ".yml")
 x$my_config_var <- 42
-write_config(x, file = tmp)
+write_config(x, path = tmp)
 readLines(tmp)
 ```
 


### PR DESCRIPTION
## Summary
Rework the `write_config()` output path argument: replace the `x@file` default with `NULL` (resolved inside the function body) and rename the argument from `file` to `path`. This avoids requiring all method implementations to share the same default expression.

Closes #48

## Changes Made
- Renamed `file` argument to `path` in the generic, `S7schema` method, and internal helper
- Changed default from `x@file` to `NULL`, resolved via fallback in `write_valid_config()`
- Updated roxygen documentation, vignettes, and NEWS entry
- Added test for the default path behavior

## Testing
- New test `"default for S7schema class"` verifies writing with the default path
- 100% test coverage confirmed
- R CMD check passes with 0 errors, 0 warnings, 0 notes

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge