### PR TITLE
feat: add /rebuild-bundle PR slash command workflow

### DIFF
--- a/.github/workflows/pr-rebuild-bundle.yml
+++ b/.github/workflows/pr-rebuild-bundle.yml
@@ -82,26 +82,29 @@ jobs:
     permissions:
       contents: write
     runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ github.token }}
+      GH_REPO: ${{ github.repository }}
+      BRANCH: ${{ needs.build.outputs.branch }}
     steps:
-      - name: Checkout PR branch
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-        with:
-          ref: ${{ needs.build.outputs.sha }}
-
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: rebuild-output
-          path: .
+          path: rebuild-output
 
-      - name: Commit rebuild outputs
+      - name: Commit rebuild outputs via API
         run: |
-          git config user.name  "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet -- inst/bundle.js dev/package-lock.json; then
-            echo "No changes to rebuild outputs"
-            exit 0
-          fi
-          git add inst/bundle.js dev/package-lock.json
-          git commit -m "chore: rebuild inst/bundle.js"
-          git push origin HEAD:${{ needs.build.outputs.branch }}
+          set -euo pipefail
+          put_file() {
+            local repo_path="$1" local_path="$2"
+            local current_sha
+            current_sha=$(gh api "repos/$GH_REPO/contents/$repo_path?ref=$BRANCH" --jq .sha)
+            gh api --method PUT "repos/$GH_REPO/contents/$repo_path" \
+              -f "message=chore: rebuild $repo_path" \
+              -f "branch=$BRANCH" \
+              -f "sha=$current_sha" \
+              -f "content=$(base64 < "$local_path" | tr -d '\n')" >/dev/null
+          }
+          put_file inst/bundle.js        rebuild-output/inst/bundle.js
+          put_file dev/package-lock.json rebuild-output/dev/package-lock.json

--- a/.github/workflows/pr-rebuild-bundle.yml
+++ b/.github/workflows/pr-rebuild-bundle.yml
@@ -1,0 +1,59 @@
+name: PR Rebuild Bundle
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions: {}
+
+jobs:
+  rebuild-bundle:
+    permissions:
+      pull-requests: write
+      contents: write
+    if: >
+      github.event.issue.pull_request &&
+      (github.event.comment.body == '/rebuild-bundle' ||
+       startsWith(github.event.comment.body, '/rebuild-bundle ')) &&
+      contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add reaction to comment
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            await github.rest.reactions.createForIssueComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              comment_id: context.payload.comment.id,
+              content: 'rocket'
+            })
+
+      - name: Checkout PR branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: refs/pull/${{ github.event.issue.number }}/head
+
+      - name: Setup Node
+        uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
+        with:
+          node-version: '20'
+
+      - name: Rebuild inst/bundle.js
+        working-directory: dev
+        run: |
+          npm install
+          npx browserify entry.js -o ../inst/bundle.js
+
+      - name: Commit bundle
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          if git diff --quiet -- inst/bundle.js; then
+            echo "No changes to inst/bundle.js"
+            exit 0
+          fi
+          git add inst/bundle.js
+          git commit -m "chore: rebuild inst/bundle.js"
+          git push

--- a/.github/workflows/pr-rebuild-bundle.yml
+++ b/.github/workflows/pr-rebuild-bundle.yml
@@ -47,11 +47,12 @@ jobs:
               return
             }
             core.setOutput('branch', pr.head.ref)
+            core.setOutput('sha', pr.head.sha)
 
       - name: Checkout PR branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ steps.pr.outputs.branch }}
+          ref: ${{ steps.pr.outputs.sha }}
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
@@ -85,7 +86,7 @@ jobs:
       - name: Checkout PR branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: ${{ needs.build.outputs.branch }}
+          ref: ${{ needs.build.outputs.sha }}
 
       - name: Download build artifacts
         uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/pr-rebuild-bundle.yml
+++ b/.github/workflows/pr-rebuild-bundle.yml
@@ -7,16 +7,18 @@ on:
 permissions: {}
 
 jobs:
-  rebuild-bundle:
+  build:
     permissions:
       pull-requests: write
-      contents: write
+      contents: read
     if: >
       github.event.issue.pull_request &&
       (github.event.comment.body == '/rebuild-bundle' ||
        startsWith(github.event.comment.body, '/rebuild-bundle ')) &&
       contains(fromJSON('["OWNER","MEMBER","COLLABORATOR"]'), github.event.comment.author_association)
     runs-on: ubuntu-latest
+    outputs:
+      branch: ${{ steps.pr.outputs.branch }}
 
     steps:
       - name: Add reaction to comment
@@ -30,30 +32,75 @@ jobs:
               content: 'rocket'
             })
 
+      - name: Resolve PR head
+        id: pr
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { data: pr } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: context.payload.issue.number,
+            })
+            if (pr.head.repo.full_name !== `${context.repo.owner}/${context.repo.repo}`) {
+              core.setFailed('Fork PRs are not supported')
+              return
+            }
+            core.setOutput('branch', pr.head.ref)
+
       - name: Checkout PR branch
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
-          ref: refs/pull/${{ github.event.issue.number }}/head
+          ref: ${{ steps.pr.outputs.branch }}
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: dev/package-lock.json
 
       - name: Rebuild inst/bundle.js
         working-directory: dev
         run: |
-          npm install
-          npx browserify entry.js -o ../inst/bundle.js
+          npm install --ignore-scripts
+          npx --no --ignore-scripts browserify entry.js -o ../inst/bundle.js
 
-      - name: Commit bundle
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        with:
+          name: rebuild-output
+          path: |
+            inst/bundle.js
+            dev/package-lock.json
+          if-no-files-found: error
+          retention-days: 1
+
+  commit:
+    needs: build
+    permissions:
+      contents: write
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout PR branch
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          ref: ${{ needs.build.outputs.branch }}
+
+      - name: Download build artifacts
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: rebuild-output
+          path: .
+
+      - name: Commit rebuild outputs
         run: |
           git config user.name  "github-actions[bot]"
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          if git diff --quiet -- inst/bundle.js; then
-            echo "No changes to inst/bundle.js"
+          if git diff --quiet -- inst/bundle.js dev/package-lock.json; then
+            echo "No changes to rebuild outputs"
             exit 0
           fi
-          git add inst/bundle.js
+          git add inst/bundle.js dev/package-lock.json
           git commit -m "chore: rebuild inst/bundle.js"
-          git push
+          git push origin HEAD:${{ needs.build.outputs.branch }}

--- a/.github/workflows/pr-rebuild-bundle.yml
+++ b/.github/workflows/pr-rebuild-bundle.yml
@@ -53,12 +53,13 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
         with:
           ref: ${{ steps.pr.outputs.sha }}
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
-          cache: 'npm'
+          node-version: "20"
+          cache: "npm"
           cache-dependency-path: dev/package-lock.json
 
       - name: Rebuild inst/bundle.js

--- a/dev/README.md
+++ b/dev/README.md
@@ -51,21 +51,24 @@ It exports the following functions that are used inside the R functions using th
 The script is bundled and put into `inst/bundle.js` in order for us to get a single `.js` file
 that can be loaded in V8 and contains all dependencies.
 
-A new bundled script is create with [Browserify](https://browserify.org):
+A new bundled script is created with [Browserify](https://browserify.org):
 
 ```bash
-browserify dev/entry.js -o inst/bundle.js
+cd dev
+npm install
+npx browserify entry.js -o ../inst/bundle.js
+cd ..
 ```
 
-Note this requires that the dependencies of `dev/entry.js` are installed.
-Install them with:
+Read more in the [Using NPM packages in V8](https://cran.r-project.org/web/packages/V8/vignettes/npm.html) vignette.
 
-```bash
-npm install ajv
-npm install js-yaml
-```
+### Automated rebuild via PR comment
 
-Read more in this the [Using NPM packages in V8](https://cran.r-project.org/web/packages/V8/vignettes/npm.html) vignette.
+On an open PR, a maintainer (OWNER/MEMBER/COLLABORATOR) can trigger a rebuild
+by commenting `/rebuild-bundle`. The workflow
+(`.github/workflows/pr-rebuild-bundle.yml`) runs browserify on the PR head and
+commits the updated `inst/bundle.js` back to the branch. Only works on
+same-repo PRs.
 
 ### License
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -5,13 +5,13 @@
 The purpose of S7schema is to provide a generic way of working with yaml
 config files. The implementation will:
 
-1.  Use S7 for easy downstream use in other packages (e.g. new child
-    classes and methods).
-2.  Use [‘ajv’](https://ajv.js.org) for validation of the config file
-    given JSON schema.
-3.  S7 class will inherit from `list` ensuring a seamless integration
-    into existing code using yaml metadata, such as whirl, connector, and
-    mighty.
+1. Use S7 for easy downstream use in other packages (e.g. new child
+   classes and methods).
+2. Use [‘ajv’](https://ajv.js.org) for validation of the config file
+   given JSON schema.
+3. S7 class will inherit from `list` ensuring a seamless integration
+   into existing code using yaml metadata, such as whirl, connector, and
+   mighty.
 
 ### Pseudo-code
 
@@ -41,15 +41,18 @@ with the supplied JSON schema.
 
 ## Updating embedded javascript
 
-The `dev/entry.js` script uses the [ajv](https://ajv.js.org) and [js-yaml](https://www.npmjs.com/package/js-yaml) node packages to validate a yaml input against a [JSON-schema](https://json-schema.org) definition.
+The `dev/entry.js` script uses the [ajv](https://ajv.js.org) and
+[js-yaml](https://www.npmjs.com/package/js-yaml) node packages to validate a
+yaml input against a [JSON-schema](https://json-schema.org) definition.
 
-It exports the following functions that are used inside the R functions using the V8 package:
+It exports the following functions that are used inside the R functions using
+the V8 package:
 
 1. `createValidator()`: Compiles AJV validator from schema string
 2. `validateYaml()`: Validates YAML string using validator
 
-The script is bundled and put into `inst/bundle.js` in order for us to get a single `.js` file
-that can be loaded in V8 and contains all dependencies.
+The script is bundled and put into `inst/bundle.js` in order for us to get a
+single `.js` file that can be loaded in V8 and contains all dependencies.
 
 A new bundled script is created with [Browserify](https://browserify.org):
 
@@ -60,7 +63,9 @@ npx browserify entry.js -o ../inst/bundle.js
 cd ..
 ```
 
-Read more in the [Using NPM packages in V8](https://cran.r-project.org/web/packages/V8/vignettes/npm.html) vignette.
+Read more in the [Using NPM packages in V8][v8-npm] vignette.
+
+[v8-npm]: https://cran.r-project.org/web/packages/V8/vignettes/npm.html
 
 ### Automated rebuild via PR comment
 
@@ -72,27 +77,32 @@ same-repo PRs.
 
 ### License
 
-Only embed javascript modules that are compatiable with the license og S7schema (APACHE 2.0).
-Currently using the following modules and licenses:
+Only embed javascript modules that are compatible with the license of
+S7schema (APACHE 2.0). Currently using the following modules and licenses:
 
-| Package                          |License      |
-|:---------------------------------|:------------|
-|node_modules/ajv                  |MIT          |
-|node_modules/argparse             |Python-2.0   |
-|node_modules/fast-deep-equal      |MIT          |
-|node_modules/fast-uri             |BSD-3-Clause |
-|node_modules/js-yaml              |MIT          |
-|node_modules/json-schema-traverse |MIT          |
-|node_modules/require-from-string  |MIT          |
+| Package                           | License      |
+|:----------------------------------|:-------------|
+| node_modules/ajv                  | MIT          |
+| node_modules/argparse             | Python-2.0   |
+| node_modules/fast-deep-equal      | MIT          |
+| node_modules/fast-uri             | BSD-3-Clause |
+| node_modules/js-yaml              | MIT          |
+| node_modules/json-schema-traverse | MIT          |
+| node_modules/require-from-string  | MIT          |
 
-Following the advice in [R Packages](https://r-pkgs.org/license.html#sec-code-you-bundle) we include the individual licenses in `inst/licenses` folder,
-mention them in `LICENSE.note` and includer their authors as copyright holders in `DESCRIPTION`.
+Following the advice in [R Packages][r-pkgs-license] we include the individual
+licenses in `inst/licenses` folder, mention them in `LICENSE.note` and include
+their authors as copyright holders in `DESCRIPTION`.
 
-We have assesded the three licenses used (MIT, Python-2.0 , and BSD-3-Clause) to be compatible with Apache 2.0, and
-therefore they can be bundled into this R package.
+[r-pkgs-license]: https://r-pkgs.org/license.html#sec-code-you-bundle
 
-If new development introduces new packages or newer version, it is required to asses their license compatibility and update the files mentioned
-above as appropiate.
+We have assessed the three licenses used (MIT, Python-2.0, and BSD-3-Clause)
+to be compatible with Apache 2.0, and therefore they can be bundled into this
+R package.
+
+If new development introduces new packages or newer versions, it is required
+to assess their license compatibility and update the files mentioned above as
+appropriate.
 
 To copy each license you can run the bash script below to copy all
 individual licenses:


### PR DESCRIPTION
## Summary
Adds a maintainer-triggered workflow that rebuilds `inst/bundle.js` from `dev/entry.js` on an open PR when someone with write access comments `/rebuild-bundle`. Removes the need to run Browserify locally and commit the bundle by hand.

Findings from megalinter (grype) will be handed in seperate PRs from dependabot (e.g. #57).

## Changes Made
- New workflow `.github/workflows/pr-rebuild-bundle.yml`:
  - Triggers on `issue_comment` matching `/rebuild-bundle`, gated on `author_association` in `{OWNER, MEMBER, COLLABORATOR}`.
  - Resolves the PR head via API and rejects fork PRs.
  - Split into two jobs: `build` runs with `contents: read` and produces the bundle + updated lockfile as an artifact; `commit` has `contents: write` and only consumes the artifact, so code executed during bundling cannot push to the repo.
  - Uses `npm install --ignore-scripts` and `npx --no --ignore-scripts` to block lifecycle scripts from PR-controlled dependencies.
  - Commits `inst/bundle.js` and `dev/package-lock.json` back to the PR branch via the GitHub contents API.
- `dev/README.md`: documents the `/rebuild-bundle` comment trigger and cleans up prose (line wrapping, list formatting, spelling).

## Testing
- N/A. Has to be on main for it to be testable.

## Checklist
- [ ] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [ ] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [ ] The PR is ready for review and merge
