### PR TITLE
fix: resolve linter findings

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -16,22 +16,16 @@
     "tests/testthat/*/**",
     "inst/bundle.js",
     "inst/licenses/*"
-    ],
+  ],
   "patterns": [
     {
       "name": "code_chunk",
       "pattern": "`{3}.*?`{3}"
     }
   ],
-  "ignoreRegExpList": [
-    "code_chunk"
-  ],
-  "words": [
-    "nolint"
-  ],
-  "dictionaries": [
-    "wordlist"
-  ],
+  "ignoreRegExpList": ["code_chunk"],
+  "words": ["nolint"],
+  "dictionaries": ["wordlist"],
   "dictionaryDefinitions": [
     {
       "name": "wordlist",

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,3 +1,4 @@
+---
 version: 2
 updates:
   - package-ecosystem: "github-actions"

--- a/.github/workflows/check_and_co.yaml
+++ b/.github/workflows/check_and_co.yaml
@@ -1,3 +1,4 @@
+---
 on:
   push:
     branches:
@@ -14,12 +15,12 @@ jobs:
     name: Check current version
     permissions:
       contents: read
-    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/check_current_version.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/check_current_version.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3  # v0.1.0
   check-nn-version:
     name: Check NN version
     permissions:
       contents: read
-    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/check_nn_versions.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/check_nn_versions.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3  # v0.1.0
     with:
       min_lock_date: "2024-08-06"
   pkgdown:
@@ -27,13 +28,13 @@ jobs:
     permissions:
       contents: write
       pull-requests: write
-    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/pkgdown.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/pkgdown.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3  # v0.1.0
   coverage:
     name: Coverage report
     permissions:
       contents: read
       pull-requests: write
-    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/coverage.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/coverage.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3  # v0.1.0
     secrets:
       CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
     with:
@@ -43,4 +44,4 @@ jobs:
     permissions:
       contents: read
       pull-requests: write
-    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/megalinter.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3 # v0.1.0
+    uses: NovoNordisk-OpenSource/r.workflows/.github/workflows/megalinter.yaml@fa1f70cce8b5544ddb31d8ea31dc2b917af1a4b3  # v0.1.0

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: S7schema
 Title: 'S7' Framework for Schema-Validated YAML Configuration
-Version: 0.1.1.9001
+Version: 0.1.1.9002
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Matthew", "Phelps", , "mewp@novonordisk.com", role = "aut"),

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,3 +1,4 @@
+---
 url: https://novonordisk-opensource.github.io/S7schema/
 
 template:

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -5,9 +5,9 @@ template:
 
 reference:
   - contents:
-    - S7schema
-    - validate_config
-    - write_config
-    - document_schema
-    - to_yaml
-    - reexports
+      - S7schema
+      - validate_config
+      - write_config
+      - document_schema
+      - to_yaml
+      - reexports

--- a/dev/README.md
+++ b/dev/README.md
@@ -77,15 +77,15 @@ V8](https://cran.r-project.org/web/packages/V8/vignettes/npm.html) vignette.
 Only embed javascript modules that are compatiable with the license og S7schema
 (APACHE 2.0). Currently using the following modules and licenses:
 
-| Package                          |License      |
-|:---------------------------------|:------------|
-|node_modules/ajv                  |MIT          |
-|node_modules/argparse             |Python-2.0   |
-|node_modules/fast-deep-equal      |MIT          |
-|node_modules/fast-uri             |BSD-3-Clause |
-|node_modules/js-yaml              |MIT          |
-|node_modules/json-schema-traverse |MIT          |
-|node_modules/require-from-string  |MIT          |
+| Package                           | License      |
+|:----------------------------------|:-------------|
+| node_modules/ajv                  | MIT          |
+| node_modules/argparse             | Python-2.0   |
+| node_modules/fast-deep-equal      | MIT          |
+| node_modules/fast-uri             | BSD-3-Clause |
+| node_modules/js-yaml              | MIT          |
+| node_modules/json-schema-traverse | MIT          |
+| node_modules/require-from-string  | MIT          |
 
 Following the advice in [R
 Packages](https://r-pkgs.org/license.html#sec-code-you-bundle) we include the

--- a/dev/README.md
+++ b/dev/README.md
@@ -5,11 +5,11 @@
 The purpose of S7schema is to provide a generic way of working with yaml
 config files. The implementation will:
 
-1.  Use S7 for easy downstream use in other packages (e.g. new child
+1. Use S7 for easy downstream use in other packages (e.g. new child
     classes and methods).
-2.  Use [‘ajv’](https://ajv.js.org) for validation of the config file
+2. Use [‘ajv’](https://ajv.js.org) for validation of the config file
     given JSON schema.
-3.  S7 class will inherit from `list` ensuring a seamless integration
+3. S7 class will inherit from `list` ensuring a seamless integration
     into existing code using yaml metadata, such as whirl, connector, and
     mighty.
 
@@ -41,15 +41,18 @@ with the supplied JSON schema.
 
 ## Updating embedded javascript
 
-The `dev/entry.js` script uses the [ajv](https://ajv.js.org) and [js-yaml](https://www.npmjs.com/package/js-yaml) node packages to validate a yaml input against a [JSON-schema](https://json-schema.org) definition.
+The `dev/entry.js` script uses the [ajv](https://ajv.js.org) and
+[js-yaml](https://www.npmjs.com/package/js-yaml) node packages to validate a
+yaml input against a [JSON-schema](https://json-schema.org) definition.
 
-It exports the following functions that are used inside the R functions using the V8 package:
+It exports the following functions that are used inside the R functions using
+the V8 package:
 
 1. `createValidator()`: Compiles AJV validator from schema string
 2. `validateYaml()`: Validates YAML string using validator
 
-The script is bundled and put into `inst/bundle.js` in order for us to get a single `.js` file
-that can be loaded in V8 and contains all dependencies.
+The script is bundled and put into `inst/bundle.js` in order for us to get a
+single `.js` file that can be loaded in V8 and contains all dependencies.
 
 A new bundled script is create with [Browserify](https://browserify.org):
 
@@ -66,12 +69,13 @@ npm install
 cd ..
 ```
 
-Read more in this the [Using NPM packages in V8](https://cran.r-project.org/web/packages/V8/vignettes/npm.html) vignette.
+Read more in this the [Using NPM packages in
+V8](https://cran.r-project.org/web/packages/V8/vignettes/npm.html) vignette.
 
 ### License
 
-Only embed javascript modules that are compatiable with the license og S7schema (APACHE 2.0).
-Currently using the following modules and licenses:
+Only embed javascript modules that are compatiable with the license og S7schema
+(APACHE 2.0). Currently using the following modules and licenses:
 
 | Package                          |License      |
 |:---------------------------------|:------------|
@@ -83,14 +87,18 @@ Currently using the following modules and licenses:
 |node_modules/json-schema-traverse |MIT          |
 |node_modules/require-from-string  |MIT          |
 
-Following the advice in [R Packages](https://r-pkgs.org/license.html#sec-code-you-bundle) we include the individual licenses in `inst/licenses` folder,
-mention them in `LICENSE.note` and includer their authors as copyright holders in `DESCRIPTION`.
+Following the advice in [R
+Packages](https://r-pkgs.org/license.html#sec-code-you-bundle) we include the
+individual licenses in `inst/licenses` folder, mention them in `LICENSE.note`
+and includer their authors as copyright holders in `DESCRIPTION`.
 
-We have assesded the three licenses used (MIT, Python-2.0 , and BSD-3-Clause) to be compatible with Apache 2.0, and
-therefore they can be bundled into this R package.
+We have assesded the three licenses used (MIT, Python-2.0 , and BSD-3-Clause)
+to be compatible with Apache 2.0, and therefore they can be bundled into this R
+package.
 
-If new development introduces new packages or newer version, it is required to asses their license compatibility and update the files mentioned
-above as appropiate.
+If new development introduces new packages or newer version, it is required to
+asses their license compatibility and update the files mentioned above as
+appropiate.
 
 To copy each license you can run the bash script below to copy all
 individual licenses:

--- a/inst/examples/config.yml
+++ b/inst/examples/config.yml
@@ -1,1 +1,1 @@
-my_config_var: 1 
+my_config_var: 1

--- a/inst/examples/config.yml
+++ b/inst/examples/config.yml
@@ -1,1 +1,2 @@
+---
 my_config_var: 1

--- a/inst/examples/definitions.json
+++ b/inst/examples/definitions.json
@@ -9,9 +9,7 @@
       "$ref": "#/definitions/my_config_var"
     }
   },
-  "required": [
-    "my_config_var"
-  ],
+  "required": ["my_config_var"],
   "additionalProperties": true,
   "definitions": {
     "my_config_var": {

--- a/tests/testthat/input/simple.yml
+++ b/tests/testthat/input/simple.yml
@@ -1,2 +1,3 @@
+---
 id: abc
 do_something: true

--- a/tests/testthat/input/simple_error.yml
+++ b/tests/testthat/input/simple_error.yml
@@ -1,2 +1,3 @@
+---
 id: abc
 error: 123

--- a/tests/testthat/schemas/definitions.json
+++ b/tests/testthat/schemas/definitions.json
@@ -21,10 +21,7 @@
       "$ref": "#/definitions/extra"
     }
   },
-  "required": [
-    "id",
-    "keys"
-  ],
+  "required": ["id", "keys"],
   "additionalProperties": true,
   "definitions": {
     "keys": {


### PR DESCRIPTION
## Summary

MegaLinter reported formatting violations across JSON, YAML and Markdown files. This PR applies the fixes so the linter job passes. No R code or package behavior is affected. Only cosmetic violations have been fixes. 

Note: New `prettier` warnings are in conflict with `yamllint` that requires two spaces before a comment. I have given first priority to `yamllint` since that results in errors from megalinter.

## Changes Made
- Reformatted JSON files (`.cspell.json`, `inst/examples/definitions.json`, `tests/testthat/schemas/definitions.json`) per prettier
- Added YAML document start markers (`---`) and fixed indentation/comment spacing in `.github/dependabot.yml`, `.github/workflows/check_and_co.yaml`, `_pkgdown.yml`, `inst/examples/config.yml` and testthat input fixtures
- Reformatted Markdown tables in `dev/README.md`

## Testing
- No new tests: changes are formatting only
- Existing test fixtures (`tests/testthat/input/*.yml`, `tests/testthat/schemas/definitions.json`) still parse and tests pass

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge