### PR TITLE
feat: create `S7schema()` object directly from a list

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: S7schema
 Title: 'S7' Framework for Schema-Validated YAML Configuration
-Version: 0.1.1.9002
+Version: 0.1.1.9003
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Matthew", "Phelps", , "mewp@novonordisk.com", role = "aut"),
@@ -46,7 +46,7 @@ Suggests:
     withr
 VignetteBuilder: 
     knitr
+Config/roxygen2/version: 8.0.0
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.3.3

--- a/R/y_S7schema.R
+++ b/R/y_S7schema.R
@@ -16,6 +16,10 @@ prop_schema <- S7::new_property(
 
 #' @noRd
 validate_prop_file <- function(value) {
+  if (value == "") {
+    return()
+  }
+
   val <- check_file(file = value, ext = c("yml", "yaml"))
   if (!isTRUE(val)) {
     return(val)
@@ -44,7 +48,19 @@ prop_validator <- S7::new_property(
 )
 
 #' @noRd
-construct_S7schema <- function(file, schema) {
+construct_S7schema <- function(file, schema, .data) {
+  rlang::check_exclusive(file, .data)
+
+  if (!rlang::is_missing(.data)) {
+    return(
+      S7::new_object(
+        .parent = .data,
+        schema = schema,
+        file = ""
+      )
+    )
+  }
+
   assert_file(file = file, ext = c("yml", "yaml"))
   validate_yaml(file, schema)
   S7::new_object(
@@ -87,6 +103,7 @@ validate_S7schema <- function(self) {
 #'
 #' @param file `character(1)` path to a yaml file to be checked.
 #' @param schema `character(1)` path to a JSON schema.
+#' @param .data `list()` input to create the object. Mutually exclusive with `file`.
 #' @section Properties:
 #' \describe{
 #'   \item{schema}{`character(1)` path to JSON schema being used to validate against.}
@@ -101,6 +118,11 @@ validate_S7schema <- function(self) {
 #'   schema = system.file("examples/schema.json", package = "S7schema")
 #' )
 #'
+#' # Create object in memory
+#' S7schema(
+#'   .data = list(my_config_var = 6),
+#'   schema = system.file("examples/schema.json", package = "S7schema")
+#' )
 #' @export
 S7schema <- S7::new_class(
   name = "S7schema",

--- a/R/y_S7schema.R
+++ b/R/y_S7schema.R
@@ -21,14 +21,14 @@
 #' @details
 #' See internal [validator()] documentation for more info on how the validation is done.
 #'
-#' @param file `character(1)` path to a yaml file to be checked.
+#' @param file `character(1)` path to a yaml file to be checked. Or `NULL` if created using `.data`.
 #' @param schema `character(1)` path to a JSON schema.
 #' @param .data `list()` input to create the object. Mutually exclusive with `file`.
 #' @section Properties:
 #' \describe{
 #'   \item{schema}{`character(1)` path to JSON schema being used to validate against.}
 #'   \item{validator}{Internal [validator()] used to validate the content (read-only).}
-#'   \item{file}{`character(1)` path to the source YAML file.}
+#'   \item{file}{`character(1)` path to the source YAML file (or `NULL` if not set).}
 #' }
 #' @returns New `S7schema` object.
 #' @examples
@@ -64,7 +64,7 @@ prop_schema <- S7::new_property(
 
 #' @noRd
 validate_prop_file <- function(value) {
-  if (value == "") {
+  if (is.null(value)) {
     return()
   }
 
@@ -76,7 +76,7 @@ validate_prop_file <- function(value) {
 
 #' @noRd
 prop_file <- S7::new_property(
-  class = S7::class_character,
+  class = NULL | S7::class_character,
   validator = \(value) {
     validate_prop_file(value)
   }
@@ -104,7 +104,7 @@ construct_S7schema <- function(file, schema, .data) {
       S7::new_object(
         .parent = .data,
         schema = schema,
-        file = ""
+        file = NULL
       )
     )
   }

--- a/R/y_S7schema.R
+++ b/R/y_S7schema.R
@@ -1,3 +1,51 @@
+#' Work with valid configurations
+#' @description
+#' `S7schema()` provides a generic way of working with yaml configuration files.
+#'
+#' The object is created by supplying both an initial YAML configuration (`file`)
+#' and the JSON schema definition (`schema`) of the configuration file.
+#'
+#' The initial configuration is validated before the new object is returned.
+#' If not valid the first error is thrown, together with a path to the entry in the YAML file,
+#' and a description of the error.
+#'
+#' The `S7schema` class inherits from `list`, ensuring that the content of the YAML
+#' file can be accessed as if read directly with `yaml::read_yaml()`, and supports
+#' the below workflow:
+
+#' 1. Read and validate config file: `x <- S7schema(...)`
+#' 2. Edit content as if it was a list: `x$new_entry <- "new_value"`
+#' 3. Validate new content against the original schema: `validate(x)`
+#' 4. Use values in downstream functions: `x$new_entry`
+#'
+#' @details
+#' See internal [validator()] documentation for more info on how the validation is done.
+#'
+#' @param file `character(1)` path to a yaml file to be checked.
+#' @param schema `character(1)` path to a JSON schema.
+#' @param .data `list()` input to create the object. Mutually exclusive with `file`.
+#' @section Properties:
+#' \describe{
+#'   \item{schema}{`character(1)` path to JSON schema being used to validate against.}
+#'   \item{validator}{Internal [validator()] used to validate the content (read-only).}
+#'   \item{file}{`character(1)` path to the source YAML file.}
+#' }
+#' @returns New `S7schema` object.
+#' @examples
+#' # Work with yaml configuration file:
+#' S7schema(
+#'   file = system.file("examples/config.yml", package = "S7schema"),
+#'   schema = system.file("examples/schema.json", package = "S7schema")
+#' )
+#'
+#' # Create object in memory
+#' S7schema(
+#'   .data = list(my_config_var = 6),
+#'   schema = system.file("examples/schema.json", package = "S7schema")
+#' )
+#' @name S7schema
+NULL
+
 #' @noRd
 validate_prop_schema <- function(value) {
   val <- check_file(file = value, ext = "json")
@@ -78,51 +126,7 @@ validate_S7schema <- function(self) {
   )
 }
 
-#' Work with valid configurations
-#' @description
-#' `S7schema()` provides a generic way of working with yaml configuration files.
-#'
-#' The object is created by supplying both an initial YAML configuration (`file`)
-#' and the JSON schema definition (`schema`) of the configuration file.
-#'
-#' The initial configuration is validated before the new object is returned.
-#' If not valid the first error is thrown, together with a path to the entry in the YAML file,
-#' and a description of the error.
-#'
-#' The `S7schema` class inherits from `list`, ensuring that the content of the YAML
-#' file can be accessed as if read directly with `yaml::read_yaml()`, and supports
-#' the below workflow:
-
-#' 1. Read and validate config file: `x <- S7schema(...)`
-#' 2. Edit content as if it was a list: `x$new_entry <- "new_value"`
-#' 3. Validate new content against the original schema: `validate(x)`
-#' 4. Use values in downstream functions: `x$new_entry`
-#'
-#' @details
-#' See internal [validator()] documentation for more info on how the validation is done.
-#'
-#' @param file `character(1)` path to a yaml file to be checked.
-#' @param schema `character(1)` path to a JSON schema.
-#' @param .data `list()` input to create the object. Mutually exclusive with `file`.
-#' @section Properties:
-#' \describe{
-#'   \item{schema}{`character(1)` path to JSON schema being used to validate against.}
-#'   \item{validator}{Internal [validator()] used to validate the content (read-only).}
-#'   \item{file}{`character(1)` path to the source YAML file.}
-#' }
-#' @returns New `S7schema` object.
-#' @examples
-#' # Work with yaml configuration file:
-#' S7schema(
-#'   file = system.file("examples/config.yml", package = "S7schema"),
-#'   schema = system.file("examples/schema.json", package = "S7schema")
-#' )
-#'
-#' # Create object in memory
-#' S7schema(
-#'   .data = list(my_config_var = 6),
-#'   schema = system.file("examples/schema.json", package = "S7schema")
-#' )
+#' @rdname S7schema
 #' @export
 S7schema <- S7::new_class(
   name = "S7schema",

--- a/R/z_write.R
+++ b/R/z_write.R
@@ -40,11 +40,18 @@ S7::method(write_config, S7schema) <- function(x, path = NULL) {
 }
 
 #' @noRd
-write_valid_config <- function(x, path) {
+write_valid_config <- function(x, path, call = parent.frame()) {
   validate(x)
 
   if (is.null(path)) {
     path <- x@file
+  }
+
+  if (!rlang::is_string(path)) {
+    cli::cli_abort(
+      "{.arg path} must be provided as {.cls character(1)}",
+      call = call
+    )
   }
 
   cat(

--- a/man/S7schema.Rd
+++ b/man/S7schema.Rd
@@ -4,12 +4,14 @@
 \alias{S7schema}
 \title{Work with valid configurations}
 \usage{
-S7schema(file, schema)
+S7schema(file, schema, .data)
 }
 \arguments{
 \item{file}{\code{character(1)} path to a yaml file to be checked.}
 
 \item{schema}{\code{character(1)} path to a JSON schema.}
+
+\item{.data}{\code{list()} input to create the object. Mutually exclusive with \code{file}.}
 }
 \value{
 New \code{S7schema} object.
@@ -53,4 +55,9 @@ S7schema(
   schema = system.file("examples/schema.json", package = "S7schema")
 )
 
+# Create object in memory
+S7schema(
+  .data = list(my_config_var = 6),
+  schema = system.file("examples/schema.json", package = "S7schema")
+)
 }

--- a/man/S7schema.Rd
+++ b/man/S7schema.Rd
@@ -7,7 +7,7 @@
 S7schema(file, schema, .data)
 }
 \arguments{
-\item{file}{\code{character(1)} path to a yaml file to be checked.}
+\item{file}{\code{character(1)} path to a yaml file to be checked. Or \code{NULL} if created using \code{.data}.}
 
 \item{schema}{\code{character(1)} path to a JSON schema.}
 
@@ -44,7 +44,7 @@ See internal \code{\link[=validator]{validator()}} documentation for more info o
 \describe{
 \item{schema}{\code{character(1)} path to JSON schema being used to validate against.}
 \item{validator}{Internal \code{\link[=validator]{validator()}} used to validate the content (read-only).}
-\item{file}{\code{character(1)} path to the source YAML file.}
+\item{file}{\code{character(1)} path to the source YAML file (or \code{NULL} if not set).}
 }
 }
 

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -11,6 +11,6 @@ These objects are imported from other packages. Follow the links
 below to see their documentation.
 
 \describe{
-  \item{S7}{\code{\link[S7]{validate}}}
+  \item{S7}{\code{\link[S7:validate]{validate()}}}
 }}
 

--- a/man/validate_config.Rd
+++ b/man/validate_config.Rd
@@ -15,7 +15,7 @@ validate_yaml(file, schema)
 
 \item{schema}{\code{character(1)} path to a JSON schema.}
 
-\item{file}{\code{character(1)} path to a yaml file to be checked.}
+\item{file}{\code{character(1)} path to a yaml file to be checked. Or \code{NULL} if created using \code{.data}.}
 }
 \value{
 \itemize{

--- a/man/validator.Rd
+++ b/man/validator.Rd
@@ -15,7 +15,7 @@ New \code{validator} object
 \description{
 Based on a JSON schema, \href{https://ajv.js.org}{ajv} is used to create a validator
 object in Javascript that can be used to check an input yaml.
-This is done in a \code{\link[V8:V8]{V8::v8()}} context, and stored inside
+This is done in a \code{\link[V8:v8]{V8::v8()}} context, and stored inside
 the \code{context} property of the the object.
 
 See \href{https://json-schema.org}{json-schema.org} on how to specify a JSON schema.
@@ -23,7 +23,7 @@ See \href{https://json-schema.org}{json-schema.org} on how to specify a JSON sch
 \section{Properties}{
 
 \describe{
-\item{context}{\code{\link[V8:V8]{V8::v8()}} context with a validator object based on the schema}
+\item{context}{\code{\link[V8:v8]{V8::v8()}} context with a validator object based on the schema}
 }
 }
 

--- a/tests/testthat/_snaps/y_schema.md
+++ b/tests/testthat/_snaps/y_schema.md
@@ -1,7 +1,0 @@
-# S7schema can be initiated witout YAML
-
-    Code
-      write_config(x)
-    Output
-      id: test
-

--- a/tests/testthat/_snaps/y_schema.md
+++ b/tests/testthat/_snaps/y_schema.md
@@ -1,0 +1,7 @@
+# S7schema can be initiated witout YAML
+
+    Code
+      write_config(x)
+    Output
+      id: test
+

--- a/tests/testthat/test-y_schema.R
+++ b/tests/testthat/test-y_schema.R
@@ -16,7 +16,7 @@ test_that("S7schema works", {
     expect_error()
 })
 
-test_that("S7schema can be initiated witout YAML", {
+test_that("S7schema can be initiated without YAML", {
   x <- S7schema(
     .data = list(id = "test"),
     schema = test_path("schemas", "simple.json")

--- a/tests/testthat/test-y_schema.R
+++ b/tests/testthat/test-y_schema.R
@@ -23,9 +23,6 @@ test_that("S7schema can be initiated witout YAML", {
   ) |>
     expect_no_condition()
 
-  write_config(x) |>
-    expect_snapshot()
-
   S7schema(
     .data = list(illegal = "entry"),
     schema = test_path("schemas", "simple.json")

--- a/tests/testthat/test-y_schema.R
+++ b/tests/testthat/test-y_schema.R
@@ -16,6 +16,29 @@ test_that("S7schema works", {
     expect_error()
 })
 
+test_that("S7schema can be initiated witout YAML", {
+  x <- S7schema(
+    .data = list(id = "test"),
+    schema = test_path("schemas", "simple.json")
+  ) |>
+    expect_no_condition()
+
+  write_config(x) |>
+    expect_snapshot()
+
+  S7schema(
+    .data = list(illegal = "entry"),
+    schema = test_path("schemas", "simple.json")
+  ) |>
+    expect_error()
+
+  S7schema(
+    .data = "non_list_input",
+    schema = test_path("schemas", "simple.json")
+  ) |>
+    expect_error()
+})
+
 test_that("validate_prop_schema() returns error for invalid input", {
   expect_match(validate_prop_schema("not_a_file.json"), "File does not exist")
 })

--- a/tests/testthat/test-z_write.R
+++ b/tests/testthat/test-z_write.R
@@ -47,3 +47,30 @@ test_that("default for S7schema class", {
 
   expect_equal(y$id, "d")
 })
+
+test_that("object created in memory", {
+  x <- S7schema(
+    .data = list(id = "test"),
+    schema = test_path("schemas", "simple.json")
+  ) |>
+    expect_no_condition()
+
+  write_config(x) |>
+    expect_error("`path` must be provided")
+
+  tmpfile <- withr::local_tempfile(
+    fileext = ".yml"
+  )
+
+  x$id <- "d"
+
+  write_config(x, tmpfile) |>
+    expect_no_condition()
+
+  y <- S7schema(
+    file = tmpfile,
+    schema = test_path("schemas", "simple.json")
+  )
+
+  expect_equal(y$id, "d")
+})


### PR DESCRIPTION
## Summary

`S7schema()` previously required a YAML file on disk. This adds a `.data` argument so an object can be constructed directly from an in-memory list, validated against the same JSON schema. `file` and `.data` are mutually exclusive, enforced with `rlang::check_exclusive()`.

When constructed from `.data`, the `file` property is set to `NULL`, and the property is typed `NULL | class_character` so the validator short-circuits instead of asserting a readable YAML path.

Closes #47

## Changes Made
- Added `.data` argument to `S7schema()`, mutually exclusive with `file`
- `construct_S7schema()` builds the object from `.data` when supplied, skipping YAML reading
- `file` property accepts `NULL` for in-memory objects
- `write_valid_config()` aborts with an informative error when no `path` is available
- Moved the class documentation block to the top of `R/y_S7schema.R` and switched `S7schema` to `@rdname`, so the docs sit above the code they describe
- Documented `.data` and added an in-memory example

## `write_config()` on in-memory objects

`write_config()` falls back to `x@file` when `path = NULL`. For an in-memory object that is `NULL`, so the call errors with `` `path` must be provided as <character(1)> `` rather than silently writing to stdout. Passing an explicit `path` writes a file as usual.

## Testing
- `S7schema can be initiated witout YAML` — construction from a list, error on data violating the schema, error on non-list input
- `object created in memory` — `write_config()` errors without a `path`, writes with one, and the result round-trips back through `S7schema()`

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge
