### PR TITLE
feat: include failing value in validation errors

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: S7schema
 Title: 'S7' Framework for Schema-Validated YAML Configuration
-Version: 0.1.1.9003
+Version: 0.1.1.9004
 Authors@R: c(
     person("Aksel", "Thomsen", , "oath@novonordisk.com", role = c("aut", "cre")),
     person("Matthew", "Phelps", , "mewp@novonordisk.com", role = "aut"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # S7schema (development version)
 
-* Validation error messages now include the current value that failed validation.
+* Validation error messages now include the current value that failed validation (#63).
 
 * Rebundled `inst/bundle.js` with updated JavaScript dependencies: `ajv` 8.17.1 → 8.18.0, `js-yaml` 4.1.0 → 4.3.1, and `fast-uri` → 3.1.5.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # S7schema (development version)
 
+* Validation error messages now include the current value that failed validation.
+
 * Rebundled `inst/bundle.js` with updated JavaScript dependencies: `ajv` 8.17.1 → 8.18.0, `js-yaml` 4.1.0 → 4.3.1, and `fast-uri` → 3.1.5.
 
 # S7schema 0.1.1

--- a/R/validator.R
+++ b/R/validator.R
@@ -68,7 +68,12 @@ fix_path <- function(path) {
 }
 
 #' @noRd
-use_validator <- function(validator, yaml_content, file = NULL, call = parent.frame()) {
+use_validator <- function(
+  validator,
+  yaml_content,
+  file = NULL,
+  call = parent.frame()
+) {
   validator@context$assign(
     name = "yaml_str",
     value = yaml_content
@@ -117,7 +122,8 @@ format_errors <- function(errors) {
     return(
       c(
         header,
-        rlang::set_names(x = bullets, nm = rep("x", length(bullets)))
+        rlang::set_names(x = bullets, nm = rep("x", length(bullets))),
+        format_value(error$data)
       )
     )
   }
@@ -145,6 +151,19 @@ format_errors <- function(errors) {
 
   c(
     header,
-    rlang::set_names(x = bullets, nm = rep("*", length(bullets)))
+    rlang::set_names(x = bullets, nm = rep("*", length(bullets))),
+    format_value(oneof_error$data)
+  )
+}
+
+#' @noRd
+format_value <- function(value) {
+  if (!rlang::is_scalar_atomic(value)) {
+    return(NULL)
+  }
+
+  rlang::set_names(
+    x = cli::format_inline("current value: {.val {value}}"),
+    nm = "i"
   )
 }

--- a/dev/entry.js
+++ b/dev/entry.js
@@ -1,7 +1,7 @@
 const Ajv = require('ajv')
 const yaml = require('js-yaml')
 
-const ajv = new Ajv()
+const ajv = new Ajv({ verbose: true })
 
 // Define createValidator function that compiles AJV validator from schema string
 function createValidator (schemaString) {

--- a/inst/bundle.js
+++ b/inst/bundle.js
@@ -3,7 +3,7 @@
 const Ajv = require('ajv')
 const yaml = require('js-yaml')
 
-const ajv = new Ajv()
+const ajv = new Ajv({ verbose: true })
 
 // Define createValidator function that compiles AJV validator from schema string
 function createValidator (schemaString) {

--- a/tests/testthat/test-validate-config.R
+++ b/tests/testthat/test-validate-config.R
@@ -69,6 +69,50 @@ test_that("validate_yaml includes file path in error messages", {
   )
 })
 
+test_that("errors include the current value when it is a scalar", {
+  # numeric value shown unquoted
+  validate_list(
+    x = list(id = 1),
+    schema = test_path("schemas", "simple.json")
+  ) |>
+    expect_error("current value: 1")
+
+  # string value shown quoted, so the type is visible
+  validate_list(
+    x = list(do_something = "yes"),
+    schema = test_path("schemas", "simple.json")
+  ) |>
+    expect_error('current value: "yes"')
+
+  # array element reports the element, not the whole array
+  validate_list(
+    x = list(my_array = list("a", 1)),
+    schema = test_path("schemas", "array.json")
+  ) |>
+    expect_error("current value: 1")
+
+  # oneOf errors also report the value
+  validate_list(
+    x = list(value = "ABC123"),
+    schema = test_path("schemas", "oneof_pattern.json")
+  ) |>
+    expect_error('current value: "ABC123"')
+})
+
+test_that("errors omit the current value when it is not a scalar", {
+  # object-level keywords report the whole object as the failing value, which
+  # would dump the entire config into the error message
+  expect_error(
+    validate_list(
+      x = list(fake = "b"),
+      schema = test_path("schemas", "simple.json")
+    ),
+    regexp = "must NOT have additional properties"
+  ) |>
+    conditionMessage() |>
+    expect_no_match("current value")
+})
+
 test_that("oneOf shows all sub-errors for invalid input", {
   validate_list(
     x = list(value = "ABC123"),


### PR DESCRIPTION
## Summary

Validation error messages did not show which value actually failed, so users had to cross-reference the JSON pointer against their config by hand. AJV can report the offending value, but only when the validator is compiled with `verbose: true`.

This enables that option and renders the value as an extra info bullet in the error message.

Before:

```
/id must be string
x type: string
```

After:

```
/id must be string
x type: string
i current value: 1
```

The value is rendered with cli's `{.val}` class, so strings are quoted and numbers are not. That distinction matters here: it makes `current value: "3.5"` (a quoted string where a number was expected) immediately distinguishable from `current value: 3.5`.

Object-level keywords such as `additionalProperties` and `required` report the *entire* object as the failing value. Emitting that would dump the whole config into the error, so the value is only shown when it is a scalar.

## Changes Made

- Compile the AJV validator with `verbose: true` in `dev/entry.js`, and rebundle `inst/bundle.js`
- Add internal `format_value()` helper in `R/validator.R`, guarded by `rlang::is_scalar_atomic()`
- Append the value bullet to both branches of `format_errors()`, covering plain errors and `oneOf` errors

## Testing

- Unit tests asserting the value appears for numeric, string, array-element and `oneOf` errors
- Unit test asserting the value is omitted for `additionalProperties`, where it would otherwise be the whole object
- Full test suite passes; package coverage remains at 100%

## Checklist
- [x] Code changes have been tested
- [x] Documentation has been updated, if applicable
- [x] All automated tests pass
- [x] Coding style and naming conventions have been followed
- [x] The PR is ready for review and merge
